### PR TITLE
0.12upgrade and azurerm >1.34

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,46 +1,47 @@
 # Providers used in this configuration
 
 provider "azurerm" {
-# subscription_id = "REPLACE-WITH-YOUR-SUBSCRIPTION-ID"
-# client_id       = "REPLACE-WITH-YOUR-CLIENT-ID"
-# client_secret   = "REPLACE-WITH-YOUR-CLIENT-SECRET"
-# tenant_id       = "REPLACE-WITH-YOUR-TENANT-ID"
+  # subscription_id = "REPLACE-WITH-YOUR-SUBSCRIPTION-ID"
+  # client_id       = "REPLACE-WITH-YOUR-CLIENT-ID"
+  # client_secret   = "REPLACE-WITH-YOUR-CLIENT-SECRET"
+  # tenant_id       = "REPLACE-WITH-YOUR-TENANT-ID"
 }
 
-provider "random" {}
+provider "random" {
+}
 
 # Create a resource group
 resource "azurerm_resource_group" "rg" {
   name     = "${var.resource_prefix}-rg"
-  location = "${var.location}"
-  tags     = "${var.tags}"
+  location = var.location
+  tags     = var.tags
 }
 
 # Create a virtual network
 resource "azurerm_virtual_network" "vnet" {
   name                = "${var.resource_prefix}-vnet"
-  location            = "${azurerm_resource_group.rg.location}"
-  address_space       = ["${var.address_space}"]
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  dns_servers         = "${var.dns_servers}"
-  tags                = "${var.tags}"
+  location            = azurerm_resource_group.rg.location
+  address_space       = [var.address_space]
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_servers         = var.dns_servers
+  tags                = var.tags
 }
 
 # Create a subnet
 resource "azurerm_subnet" "subnet" {
-  name                 = "${var.subnet_name}"
-  virtual_network_name = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name  = "${azurerm_resource_group.rg.name}"
-  address_prefix       = "${var.subnet_prefix}"
-  service_endpoints    = ["${var.service_endpoints}"]
+  name                 = var.subnet_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = azurerm_resource_group.rg.name
+  address_prefix       = var.subnet_prefix
+  service_endpoints    = var.service_endpoints
 }
 
 # Create a network security group
 resource "azurerm_network_security_group" "nsg" {
   name                = "${var.resource_prefix}-nsg"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  tags                = "${var.tags}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = var.tags
 }
 
 # Create network security group rules to secure HDInsight management traffic
@@ -51,11 +52,11 @@ resource "azurerm_network_security_rule" "nsg_rule_allow_hdi_mgmt_traffic" {
   access                      = "Allow"
   protocol                    = "*"
   source_port_range           = "*"
-  source_address_prefixes     = ["${var.source_address_prefixes_mgmt}"]
+  source_address_prefixes     = var.source_address_prefixes_mgmt
   destination_port_range      = "443"
   destination_address_prefix  = "VirtualNetwork"
-  resource_group_name         = "${azurerm_resource_group.rg.name}"
-  network_security_group_name = "${azurerm_network_security_group.nsg.name}"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
 }
 
 resource "azurerm_network_security_rule" "nsg_rule_allow_azure_resolver_traffic" {
@@ -65,11 +66,11 @@ resource "azurerm_network_security_rule" "nsg_rule_allow_azure_resolver_traffic"
   access                      = "Allow"
   protocol                    = "*"
   source_port_range           = "*"
-  source_address_prefix       = "${var.source_address_prefix_resolver}"
+  source_address_prefix       = var.source_address_prefix_resolver
   destination_port_range      = "443"
   destination_address_prefix  = "VirtualNetwork"
-  resource_group_name         = "${azurerm_resource_group.rg.name}"
-  network_security_group_name = "${azurerm_network_security_group.nsg.name}"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
 }
 
 resource "azurerm_network_security_rule" "nsg_rule_allow_hdi_mgmt_traffic_regional" {
@@ -79,41 +80,42 @@ resource "azurerm_network_security_rule" "nsg_rule_allow_hdi_mgmt_traffic_region
   access                      = "Allow"
   protocol                    = "*"
   source_port_range           = "*"
-  source_address_prefixes     = ["${var.source_address_prefixes_mgmt_region}"]
+  source_address_prefixes     = var.source_address_prefixes_mgmt_region
   destination_port_range      = "443"
   destination_address_prefix  = "VirtualNetwork"
-  resource_group_name         = "${azurerm_resource_group.rg.name}"
-  network_security_group_name = "${azurerm_network_security_group.nsg.name}"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
 }
 
 resource "azurerm_subnet_network_security_group_association" "subnet_to_nsg" {
-  subnet_id                 = "${azurerm_subnet.subnet.id}"
-  network_security_group_id = "${azurerm_network_security_group.nsg.id}"
+  subnet_id                 = azurerm_subnet.subnet.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
 }
 
 # Create storage accounts
 
 resource "random_id" "storage_account_name_unique" {
-  count       = "${var.storage_account_count}"
+  count       = var.storage_account_count
   byte_length = 8
 }
 
 resource "azurerm_storage_account" "storage" {
-  count                    = "${var.storage_account_count}"
-  name                     = "${element(random_id.storage_account_name_unique.*.hex, count.index)}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${azurerm_resource_group.rg.location}"
+  count                    = var.storage_account_count
+  name                     = element(random_id.storage_account_name_unique.*.hex, count.index)
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
   account_kind             = "StorageV2"
   account_tier             = "Standard"
   access_tier              = "Hot"
-  account_replication_type = "${var.account_replication_type}"
+  account_replication_type = var.account_replication_type
 
   network_rules {
     ip_rules                   = ["127.0.0.1"]
-    virtual_network_subnet_ids = ["${azurerm_subnet.subnet.id}"]
+    virtual_network_subnet_ids = [azurerm_subnet.subnet.id]
+    default_action             = "Deny"
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 # Create SQL Databases
@@ -122,44 +124,45 @@ resource "random_id" "sql_dbserver_name_unique" {
 }
 
 resource "azurerm_sql_server" "dbserver" {
-  count                        = "${length(var.azuresqldb_databases) > 0 ? 1 : 0}"
-  name                         = "${random_id.sql_dbserver_name_unique.hex}"
-  resource_group_name          = "${azurerm_resource_group.rg.name}"
-  location                     = "${azurerm_resource_group.rg.location}"
+  count                        = length(var.azuresqldb_databases) > 0 ? 1 : 0
+  name                         = random_id.sql_dbserver_name_unique.hex
+  resource_group_name          = azurerm_resource_group.rg.name
+  location                     = azurerm_resource_group.rg.location
   version                      = "12.0"
-  administrator_login          = "${var.sql_server_admin_user}"
-  administrator_login_password = "${var.sql_server_admin_password}"
-  tags                         = "${var.tags}"
+  administrator_login          = var.sql_server_admin_user
+  administrator_login_password = var.sql_server_admin_password
+  tags                         = var.tags
 }
 
 # Enables the "Allow Access to Azure services" box as described in the API docs 
 # https://docs.microsoft.com/en-us/rest/api/sql/firewallrules/createorupdate
 
 resource "azurerm_sql_firewall_rule" "sqlfw" {
-  count               = "${length(var.azuresqldb_databases) > 0 ? 1 : 0}"
+  count               = length(var.azuresqldb_databases) > 0 ? 1 : 0
   name                = "allow-azure-services"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  server_name         = "${azurerm_sql_server.dbserver.name}"
+  resource_group_name = azurerm_resource_group.rg.name
+  server_name         = azurerm_sql_server.dbserver[0].name
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
 }
 
 resource "azurerm_sql_virtual_network_rule" "sqlvnet" {
-  count               = "${length(var.azuresqldb_databases) > 0 ? 1 : 0}"
+  count               = length(var.azuresqldb_databases) > 0 ? 1 : 0
   name                = "allow-vnet"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  server_name         = "${azurerm_sql_server.dbserver.name}"
-  subnet_id           = "${azurerm_subnet.subnet.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  server_name         = azurerm_sql_server.dbserver[0].name
+  subnet_id           = azurerm_subnet.subnet.id
 }
 
 resource "azurerm_sql_database" "sqldatabase" {
-  count                            = "${length(var.azuresqldb_databases)}"
-  name                             = "${var.azuresqldb_databases[count.index]}"
-  resource_group_name              = "${azurerm_resource_group.rg.name}"
-  location                         = "${azurerm_resource_group.rg.location}"
+  count                            = length(var.azuresqldb_databases)
+  name                             = var.azuresqldb_databases[count.index]
+  resource_group_name              = azurerm_resource_group.rg.name
+  location                         = azurerm_resource_group.rg.location
   edition                          = "Basic"
   collation                        = "SQL_Latin1_General_CP1_CI_AS"
   create_mode                      = "Default"
   requested_service_objective_name = "Basic"
-  server_name                      = "${azurerm_sql_server.dbserver.name}"
+  server_name                      = azurerm_sql_server.dbserver[0].name
 }
+

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -20,7 +20,7 @@ subnet_name = "hdinsight" # Change this to the name of the subnet you want to us
 
 subnet_prefix = "10.0.1.0/24" # Change this to the address space you want to use for the subnet, must be contained within vnet address_space
 
-service_endpoints = ["Microsoft.Sql","Microsoft.Storage"] # Change this to the specific service endpoints you want to enable.
+service_endpoints = ["Microsoft.Sql", "Microsoft.Storage"] # Change this to the specific service endpoints you want to enable.
 
 # NSGs
 source_address_prefixes_mgmt = ["168.61.49.99", "23.99.5.239", "168.61.48.131", "138.91.141.162"] # Required for all HDInsight Vnets

--- a/variables.tf
+++ b/variables.tf
@@ -1,18 +1,18 @@
 # General 
 variable "resource_prefix" {
-  type = "string"
+  type        = string
   description = "The prefix used for all resources in this example"
   default     = "hdi-secure-vnet"
 }
 
 variable "location" {
-  type = "string"
+  type        = string
   description = "The Azure Region in which the resources in this example should exist"
   default     = "West US 2"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Any tags which should be assigned to the resources in this plan"
 
   default = {
@@ -24,25 +24,25 @@ variable "tags" {
 
 # VNet 
 variable "address_space" {
-  type = "string"
+  type        = string
   description = "The address space that is used by the virtual network."
   default     = "10.0.0.0/16"
 }
 
 variable "dns_servers" {
-  type = "list"
+  type        = list(string)
   description = "The DNS servers to be used by the virtual network"
   default     = []
 }
 
 variable "subnet_prefix" {
-  type = "string"
+  type        = string
   description = "The address prefix to use for the subnet."
   default     = "10.0.1.0/24"
 }
 
 variable "subnet_name" {
-  type = "string"
+  type        = string
   description = "The name to use for the subnet."
   default     = "hdi-secure"
 }
@@ -51,9 +51,9 @@ variable "subnet_name" {
 # Docs: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview
 
 variable "service_endpoints" {
-  type = "list"
+  type        = list(string)
   description = "The service endoints to enable on the subnet."
-  default     = ["Microsoft.Sql","Microsoft.Storage"]
+  default     = ["Microsoft.Sql", "Microsoft.Storage"]
 }
 
 # NSGs
@@ -61,19 +61,19 @@ variable "service_endpoints" {
 # Docs: https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-extend-hadoop-virtual-network#hdinsight-ip-1
 
 variable "source_address_prefixes_mgmt" {
-  type        = "list"
+  type        = list(string)
   description = "Used in NSG rule to enable management traffic for HD Insight"
   default     = ["168.61.49.99", "23.99.5.239", "168.61.48.131", "138.91.141.162"]
 }
 
 variable "source_address_prefix_resolver" {
-  type = "string"
+  type        = string
   description = "Used in NSG rule to enable Azure Resolver traffic to HD Insight"
   default     = "168.63.129.16"
 }
 
 variable "source_address_prefixes_mgmt_region" {
-  type        = "list"
+  type        = list(string)
   description = "Used in NSG rule to enable management traffic for HD Insight"
   default = [
     "23.102.235.122",
@@ -131,34 +131,36 @@ variable "source_address_prefixes_mgmt_region" {
     "13.64.254.98",
     "23.101.196.19",
     "52.175.211.210",
-    "52.175.222.222"
+    "52.175.222.222",
   ]
 }
 
 # Azure Storage Accounts  for HDInsight
 variable "storage_account_count" {
   description = "The number of storage acccounts you want to deploy"
-  default = 1
+  default     = 1
 }
+
 variable "account_replication_type" {
-  type = "string"
+  type        = string
   description = "Account type for storage accounts ('LRS', 'GRS' or 'RAGRS'.  'ZRS' probably does not apply to HD Insight)"
-  default = "LRS"
+  default     = "LRS"
 }
 
 # Azure SQL Databases for HDInsight Hive Metastore or Oozie
 variable "azuresqldb_databases" {
-  type = "list"
+  type        = list(string)
   description = "The names of the Azure SQL Databases to create. Leave this empty if you don't want to create any."
-  default = ["hivemetastoredb","ooziedb"]
+  default     = ["hivemetastoredb", "ooziedb"]
 }
 
 variable "sql_server_admin_user" {
-  type = "string"
+  type        = string
   description = "The admin user for the Azure SQL Database server."
 }
 
 variable "sql_server_admin_password" {
-  type = "string"
+  type        = string
   description = "The password for the Azure SQL Database admin user."
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Hi, i decided to use this module for one of our new cluster builds but it was only for Terraform 11.x so i Updated for
- Terraform 12.x 
- Azurerm provider ~>1.34 
->  added default_action for azurerm_storage_account network_rules (required in azurerm ~1.33)

$ terraform version
Terraform v0.12.8
+ provider.azurerm v1.35.0
+ provider.random v2.2.1
+ provider.tls v2.1.1